### PR TITLE
chore: update repository URLs to xyo-financial/sdk-node and bump version to v1.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # XYO.Financial SDK for Node.js
 
 <p align="center">
-    <a href="https://xyo.financial" target="blank"><img alt="XYO Financial Logo" width="50%" src="https://github.com/syniol/xyo-sdk-node/blob/main/docs/mascot.png?raw=true" /></a>
+    <a href="https://xyo.financial" target="blank"><img alt="XYO Financial Logo" width="50%" src="https://github.com/xyo-financial/sdk-node/blob/main/docs/mascot.png?raw=true" /></a>
     <br/>
     <b>Enterprise-Grade Financial Transaction Enrichment SDK for Node.js</b>
 </p>
 
 <p align="center">
-    <img src="https://github.com/syniol/xyo-sdk-node/actions/workflows/release.yml/badge.svg" alt="Release Pipeline" />
+    <img src="https://github.com/xyo-financial/sdk-node/actions/workflows/release.yml/badge.svg" alt="Release Pipeline" />
     <img src="https://img.shields.io/badge/Security-npm%20audit%20passing-success" alt="Security Audit" />
     <img src="https://img.shields.io/badge/TypeScript-Strict-blue" alt="TypeScript Strict" />
     <img src="https://img.shields.io/badge/Node.js-%3E%3D18.0.0-brightgreen" alt="Node Compatibility" />

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -14,7 +14,7 @@
     },
     "..": {
       "name": "xyo-sdk",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "carbon-http": "^2.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xyo-sdk",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xyo-sdk",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "carbon-http": "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyo-sdk",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "XYO SDK to connect and consume AI Banking Transaction Enrichment",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/syniol/xyo-sdk-node.git"
+    "url": "git+https://github.com/xyo-financial/sdk-node.git"
   },
   "keywords": [
     "XYO",
@@ -34,9 +34,9 @@
   "author": "Hadi Tajallaei <hadi@syniol.com>",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/syniol/xyo-sdk-node/issues"
+    "url": "https://github.com/xyo-financial/sdk-node/issues"
   },
-  "homepage": "https://github.com/syniol/xyo-sdk-node#readme",
+  "homepage": "https://github.com/xyo-financial/sdk-node#readme",
   "devDependencies": {
     "@eslint/js": "^9.34.0",
     "@types/node": "24.2.1",


### PR DESCRIPTION
Updates GitHub repository URLs across documentation and package metadata, and bumps patch version to v1.2.3.