### PR TITLE
feat(sdk): ISO 3166-1 alpha-2 validation and xApiUser CRLF injection protection (CWE-113)

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -398,6 +398,25 @@ describe('XYO Financial SDK - Node.js Test Suite', () => {
       assert.equal(response.location, 'London, GB')
     })
 
+    it('rejects invalid countryCode that is not 2 characters', async () => {
+      const client = new XYOClient({ apiKey: 'token' })
+
+      await assert.rejects(
+        async () => {
+          await client.enrichTransaction({
+            content: 'TEST TX',
+            countryCode: 'USA',
+          })
+        },
+        (err: Error) => {
+          assert.ok(
+            err.message.includes('ISO 3166-1 alpha-2 two-letter code'),
+          )
+          return true
+        },
+      )
+    })
+
     it('handles 400 Bad Request error with RFC 7807 problem details', async () => {
       const problemDetails: ErrorResponse = {
         errors: [
@@ -757,6 +776,32 @@ describe('XYO Financial SDK - Node.js Test Suite', () => {
       )
     })
 
+    it('supports xApiUser in client.enrichTransactions and rejects CRLF injection', async () => {
+      mockFetchHandler = async () =>
+        createJsonResponse(mockBulkResponse, 200)
+
+      const client = new XYOClient({ apiKey: 'token' })
+
+      await client.enrichTransactions(
+        [{ content: 'TX', countryCode: 'GB' }],
+        'user-abc',
+      )
+      assert.equal(capturedRequests[0].headers['x-api-user'], 'user-abc')
+
+      await assert.rejects(
+        async () => {
+          await client.enrichTransactions(
+            [{ content: 'TX', countryCode: 'GB' }],
+            'user\r\nInjected: evil',
+          )
+        },
+        (err: Error) => {
+          assert.ok(err.message.includes('CR or LF characters'))
+          return true
+        },
+      )
+    })
+
     it('handles bulk submission 400 Bad Request error', async () => {
       const errorPayload: ErrorResponse = {
         errors: [
@@ -951,7 +996,27 @@ describe('XYO Financial SDK - Node.js Test Suite', () => {
       )
     })
 
-    it('throws RequiredError when ID parameter is null or undefined', async () => {
+    it('supports xApiUser in client.getEnrichmentStatus and rejects CRLF injection', async () => {
+      mockFetchHandler = async () =>
+        createJsonResponse({ status: 'READY' }, 200)
+
+      const client = new XYOClient({ apiKey: 'token' })
+
+      await client.getEnrichmentStatus('job-xyz', 'tenant-user-1')
+      assert.equal(capturedRequests[0].headers['x-api-user'], 'tenant-user-1')
+
+      await assert.rejects(
+        async () => {
+          await client.getEnrichmentStatus('job-xyz', 'user\r\nEvil: true')
+        },
+        (err: Error) => {
+          assert.ok(err.message.includes('CR or LF characters'))
+          return true
+        },
+      )
+    })
+
+    it('throws Error when ID parameter is null or empty', async () => {
       const client = new XYOClient({ apiKey: 'token' })
 
       await assert.rejects(
@@ -959,10 +1024,18 @@ describe('XYO Financial SDK - Node.js Test Suite', () => {
           // @ts-expect-error Testing runtime null guard
           await client.getEnrichmentStatus(null)
         },
-        (err: unknown) => {
-          assert.ok(err instanceof RequiredError)
-          assert.equal(err.name, 'RequiredError')
-          assert.equal(err.field, 'id')
+        (err: Error) => {
+          assert.ok(err.message.includes('id cannot be empty'))
+          return true
+        },
+      )
+
+      await assert.rejects(
+        async () => {
+          await client.getEnrichmentStatus('')
+        },
+        (err: Error) => {
+          assert.ok(err.message.includes('id cannot be empty'))
           return true
         },
       )

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,6 +177,11 @@ export class XYOClient {
       enrichTransaction: async (
         request: EnrichmentRequest,
       ): Promise<EnrichmentResponse> => {
+        if (request.countryCode && request.countryCode.trim().length !== 2) {
+          throw new Error(
+            'enrichTransaction: countryCode must be an ISO 3166-1 alpha-2 two-letter code',
+          )
+        }
         return this._api.enrichTransaction({
           enrichmentRequest: request,
         })
@@ -187,8 +192,13 @@ export class XYOClient {
        */
       enrichTransactions: async (
         transactions: EnrichTransactionsRequestInner[],
+        xApiUser?: string,
       ): Promise<EnrichTransactionCollectionResponse> => {
+        if (xApiUser && (xApiUser.includes('\r') || xApiUser.includes('\n'))) {
+          throw new Error('enrichTransactions: xApiUser must not contain CR or LF characters')
+        }
         return this._api.enrichTransactions({
+          xApiUser,
           enrichTransactionsRequestInner: transactions,
         })
       },
@@ -198,8 +208,15 @@ export class XYOClient {
        */
       getEnrichmentStatus: async (
         id: string,
+        xApiUser?: string,
       ): Promise<EnrichmentCollectionStatusResponse> => {
-        return this._api.getEnrichmentStatus({ id })
+        if (typeof id !== 'string' || !id.trim()) {
+          throw new Error('getEnrichmentStatus: id cannot be empty')
+        }
+        if (xApiUser && (xApiUser.includes('\r') || xApiUser.includes('\n'))) {
+          throw new Error('getEnrichmentStatus: xApiUser must not contain CR or LF characters')
+        }
+        return this._api.getEnrichmentStatus({ id, xApiUser })
       },
 
       /**
@@ -228,8 +245,9 @@ export class XYOClient {
    */
   public async enrichTransactions(
     transactions: EnrichTransactionsRequestInner[],
+    xApiUser?: string,
   ): Promise<EnrichTransactionCollectionResponse> {
-    return this.enrichment.enrichTransactions(transactions)
+    return this.enrichment.enrichTransactions(transactions, xApiUser)
   }
 
   /**
@@ -237,8 +255,9 @@ export class XYOClient {
    */
   public async getEnrichmentStatus(
     id: string,
+    xApiUser?: string,
   ): Promise<EnrichmentCollectionStatusResponse> {
-    return this.enrichment.getEnrichmentStatus(id)
+    return this.enrichment.getEnrichmentStatus(id, xApiUser)
   }
 
   /**


### PR DESCRIPTION
## Enterprise Hardening Refinements

1. **CWE-113 Prevention**: Sanitizes and rejects CR/LF control characters in `xApiUser` parameter to prevent HTTP header injection.
2. **Pre-flight Country Code Validation**: Validates ISO 3166-1 alpha-2 two-letter code format before network dispatch.
3. **Parameter Validation**: Enforces non-empty batch IDs in `getEnrichmentStatus`.
4. **Test Suite Coverage**: Adds full test scenarios covering header injection and input validations.