### PR TITLE
ci: remove npm whoami from release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,9 +156,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Verify Token and Publish to NPM
+      - name: Publish to NPM
         run: |
-          npm whoami
           npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Clean up

Removed `npm whoami` from the NPM publish step as it was a debugging artifact and is not required for the standard `npm publish --provenance`.

Closes: https://github.com/xyo-financial/sdk-node/issues/10